### PR TITLE
AppData: Fix screenshot URLs

### DIFF
--- a/data/com.github.jeysonflores.hasher.appdata.xml
+++ b/data/com.github.jeysonflores.hasher.appdata.xml
@@ -45,13 +45,13 @@
 	</releases>
 	<screenshots>
 		<screenshot type="default">
-			<image>https://github.com/JeysonFlores/hasher/blob/main/data/assets/screenshots/screenshot-1.png</image>
+			<image>https://raw.githubusercontent.com/JeysonFlores/hasher/main/data/assets/screenshots/screenshot-1.png</image>
 		</screenshot>
 		<screenshot>
-			<image>https://github.com/JeysonFlores/hasher/blob/main/data/assets/screenshots/screenshot-2.png</image>
+			<image>https://raw.githubusercontent.com/JeysonFlores/hasher/main/data/assets/screenshots/screenshot-2.png</image>
 		</screenshot>
 		<screenshot>
-			<image>https://github.com/JeysonFlores/hasher/blob/main/data/assets/screenshots/screenshot-3.png</image>
+			<image>https://raw.githubusercontent.com/JeysonFlores/hasher/main/data/assets/screenshots/screenshot-3.png</image>
 		</screenshot>
 	</screenshots>
 	<developer_name>Jeyson Antonio Flores Deras</developer_name>


### PR DESCRIPTION
These need to point to the raw versions; with the previous URLs, GitHub loads a web page instead of an image.